### PR TITLE
Change tabbing from 4 to 2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
           "*.(js|jsx|ts|tsx)"
         ],
         "options": {
-          "tabWidth": 4
+          "tabWidth": 2
         }
       }
     ]

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,8 +12,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
   },
   "include": ["src"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
This changes the default tabbing to be 2 spaces instead of the current
4 spaces.

tsconfig.json is also changed to add missing commas

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
