### PR TITLE
fix: memoize dependencies in `ResultProgressStep`

### DIFF
--- a/frontend/src/app/Results/ResultProgressStep.tsx
+++ b/frontend/src/app/Results/ResultProgressStep.tsx
@@ -46,7 +46,7 @@ export const ResultProgressStep: React.FC<ResultProgressStepProps> = ({
         Submitted
       </ProgressStep>
     );
-  }, [startTime]);
+  }, [startTime, submittedTime]);
 
   const startStep = useMemo(() => {
     const isPending = !startTime;
@@ -98,7 +98,7 @@ export const ResultProgressStep: React.FC<ResultProgressStepProps> = ({
         {noun} {isPending ? "Pending" : isCurrent ? "In Progress" : "Done"}
       </ProgressStep>
     );
-  }, [startTime]);
+  }, [startTime, finishedTime, noun]);
 
   return (
     <ProgressStepper aria-label={`Current ${noun.toLowerCase()} status`}>


### PR DESCRIPTION
Some dependencies to `useMemo` in ResultProgressStep wasn't updated and
didn't render properly. This should have been caught by linting when
this was being implemented. The linting should be fixed by #392

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
